### PR TITLE
HC-281: authenticate docker hub pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   test:
     docker:
       - image: hysds/pge-base:latest
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     steps:
       - checkout
       - run:
@@ -16,7 +19,10 @@ workflows:
   version: 2
   test:
     jobs:
-      - test
+      - test:
+          context:
+            - docker-hub-creds
+            - git-oauth-token
   weekly:
     triggers:
       - schedule:
@@ -27,6 +33,9 @@ workflows:
                 - develop
     jobs:
       - test:
+          context:
+            - docker-hub-creds
+            - git-oauth-token
           filters:
             branches:
               only: develop


### PR DESCRIPTION
Created contexts docker-hub-creds and git-oauth-token and updated CircleCI config for authenticated docker pulls.