### PR TITLE
HC-563: Update Python version to 3.12+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: hysds/pge-base:HC-563
+      - image: hysds/pge-base:latest
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             python setup.py test
   build:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.12
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -25,15 +25,16 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            pip install pytest==7.2.0
-            pip install .
+            python -m pip install --upgrade pip
+            pip install pytest
+            pip install -e .
       - run:
-          name: pytest
+          name: Run tests
           command: |
-            pytest .
+            python -m pytest -v
   publish-pypi:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.12
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: hysds/pge-base:latest
+      - image: hysds/pge-base:HC-563
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -13,7 +13,8 @@ jobs:
           command: |
             source $HOME/verdi/bin/activate
             cp $HOME/verdi/ops/hysds/configs/celery/celeryconfig.py.tmpl $HOME/verdi/ops/hysds/celeryconfig.py
-            python setup.py test
+            pip install -e .
+            pytest .
   build:
     docker:
       - image: cimg/python:3.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Support for Python 3.12+
+- New CHANGELOG.md and updated CONTRIBUTING.md files
+
+### Changed
+- Updated `setup.py` to require Python 3.12 or higher
+- Removed Python 2 compatibility code and dependencies
+- Updated datetime handling to use timezone-aware objects
+- Updated test cases to use modern Python features
+- Improved documentation and contribution guidelines
+
+### Removed
+- Removed dependency on the `future` package
+- Removed support for Python versions below 3.12
+
+## [0.2.3] - YYYY-MM-DD
+
+### Added
+- Initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to PROV-ES
+
+Thank you for your interest in contributing to PROV-ES! We welcome contributions from the community.
+
+## Prerequisites
+
+- Python 3.12 or higher
+- Git
+- pip (Python package manager)
+
+## Development Setup
+
+1. Fork the repository on GitHub
+2. Clone your fork locally:
+   ```bash
+   git clone https://github.com/your-username/prov_es.git
+   cd prov_es
+   ```
+3. Create a virtual environment:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   ```
+4. Install development dependencies:
+   ```bash
+   pip install -e .[dev]
+   ```
+
+## Code Style
+
+We use the following tools to maintain code quality:
+
+- **Black** for code formatting
+- **isort** for import sorting
+- **flake8** for linting
+
+Before submitting a pull request, please run:
+
+```bash
+black .
+isort .
+flake8
+pytest
+```
+
+## Pull Request Process
+
+1. Create a feature branch from the `main` branch
+2. Make your changes
+3. Add tests for your changes
+4. Update documentation if needed
+5. Run tests and ensure they pass
+6. Submit a pull request with a clear description of your changes
+
+## Reporting Issues
+
+When reporting issues, please include:
+
+- A clear description of the issue
+- Steps to reproduce the issue
+- Expected behavior
+- Actual behavior
+- Python version and operating system
+
+## License
+
+By contributing to this project, you agree that your contributions will be licensed under the project's [LICENSE](LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 [![CircleCI](https://circleci.com/gh/hysds/prov_es.svg?style=svg)](https://circleci.com/gh/hysds/prov_es)
 
-PROV-ES (Provenance for Earth Science) python library.
+PROV-ES (Provenance for Earth Science) Python library.
+
+## Requirements
+
+- Python 3.12 or higher
+
+## Installation
+
+```bash
+pip install prov_es
+```
+
+## Documentation
 
 Documentation can be found at http://hysds.github.io/prov_es/index.html.
+
+## Changes in Python 3.12+ Version
+
+- Removed Python 2 compatibility code and dependencies
+- Updated to use modern Python 3.12 features
+- Removed dependency on the `future` package
+- Updated datetime handling to use timezone-aware objects
+
+## Contributing
+
+Contributions are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # prov_es documentation build configuration file, created by
 # sphinx-quickstart on Tue Jul 14 16:50:51 2015.
@@ -12,12 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import sys
 import os
 import shlex

--- a/prov_es/__init__.py
+++ b/prov_es/__init__.py
@@ -1,10 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
-
-__version__ = get_distribution('prov_es').version
+__version__ = version('prov_es')

--- a/prov_es/constants.py
+++ b/prov_es/constants.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from prov.identifier import Namespace
 
 HYSDS = Namespace('hysds', 'http://hysds.domain.com/hysds/0.1#')

--- a/prov_es/model.py
+++ b/prov_es/model.py
@@ -1,12 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-from builtins import super
-from builtins import str
-from future import standard_library
-standard_library.install_aliases()
 import os
 import re
 import types
@@ -46,7 +37,7 @@ class ProvEsDocument(ProvDocument):
         # track organizations to remove redundancy
         self.prov_es_orgs = {}
 
-        super(ProvEsDocument, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def collection(self, id, doi=None, shortName=None, longName=None,
                    location=[], sourceInstrument=[], level=None,
@@ -287,7 +278,7 @@ class ProvEsDocument(ProvDocument):
         if len(usesSoftware) > 0:
             attrs.append((EOS_USESSOFTWARE, tuple(usesSoftware)))
         if wasAssociatedWith is not None:
-            waw_id = "hysds:%s" % get_uuid("%s:%s" % (id, wasAssociatedWith))
+            waw_id = "hysds:%s" % get_uuid("{}:{}".format(id, wasAssociatedWith))
             waw_attrs = {}
             if wasAssociatedWithRole is not None:
                 waw_attrs[PROV_ROLE] = wasAssociatedWithRole
@@ -315,7 +306,7 @@ class ProvEsDocument(ProvDocument):
         for input in used:
             if start_time is not None:
                 used_id = "hysds:%s" % get_uuid(
-                    "%s:%s:%s" % (ps, input, start_time))
+                    "{}:{}:{}".format(ps, input, start_time))
                 if bundle:
                     bundle.used(ps, input, start_time, used_id, input_attrs)
                 else:
@@ -324,7 +315,7 @@ class ProvEsDocument(ProvDocument):
         for output in generated:
             if end_time is not None:
                 gen_id = "hysds:%s" % get_uuid(
-                    "%s:%s:%s" % (output, ps, end_time))
+                    "{}:{}:{}".format(output, ps, end_time))
                 if bundle:
                     bundle.wasGeneratedBy(
                         output, ps, end_time, gen_id, output_attrs)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['prov>=2.0.0'],
+    install_requires=['prov==1.3.1', 'future>=0.17.1'],
     python_requires='>=3.12',
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,21 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 setup(
     name='prov_es',
-    version='0.2.3',
+    version='0.3.0',
     long_description='PROV-ES python library',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['prov==1.3.1', 'future>=0.17.1'],
+    install_requires=['prov>=2.0.0'],
+    python_requires='>=3.12',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: POSIX :: Linux",
         "Operating System :: Unix",
         "Operating System :: MacOS :: MacOS X",

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from prov_es.model import ProvEsDocument
 
 
@@ -82,10 +76,10 @@ def test_ProvEsDocument():
 
     # process step
     proc_id = "hysds:create_interferogram-INSAR20130625_673969_2940232"
-    start_time = datetime.utcnow()
+    start_time = datetime.now(timezone.utc)
     end_time = start_time + timedelta(seconds=12233)
-    ps = doc.processStep(proc_id, start_time.isoformat() + 'Z',
-                         end_time.isoformat() + 'Z', [software],
+    ps = doc.processStep(proc_id, start_time.isoformat(timespec='seconds').replace('+00:00', 'Z'),
+                         end_time.isoformat(timespec='seconds').replace('+00:00', 'Z'), [software],
                          sa_id, rt_ctx_id, [id, dem_id], [out_id],
                          wasAssociatedWithRole="softwareAgent")
 


### PR DESCRIPTION
Overview
Successfully upgraded the prov_es package to Python 3.12+ compatibility. This update removes Python 2 compatibility code and modernizes the codebase.

Changes Made
1. Python Version and Dependencies
Updated setup.py to require Python 3.12+
Removed future package dependency
Updated prov dependency to >=2.0.0
Bumped version to 0.3.0 (following semantic versioning)
2. Code Updates
Removed all __future__ imports
Updated datetime handling to use timezone-aware objects
Replaced pkg_resources with importlib.metadata for package version
Fixed test cases to use modern Python features
3. Documentation
Updated README.md with Python 3.12 requirements
Added CONTRIBUTING.md with contribution guidelines
Created CHANGELOG.md to track changes
Updated inline code documentation
4. CI/CD
Updated CircleCI configuration to use Python 3.12
Modernized build and test process